### PR TITLE
fixed: failed to rtcon with OpenRTM.NET

### DIFF
--- a/rtctree/ports.py
+++ b/rtctree/ports.py
@@ -100,14 +100,14 @@ class Port(object):
             if self.porttype == 'DataInPort' or self.porttype == 'DataOutPort':
                 for prop in props:
                     if prop in self.properties:
-                        if props[prop] not in self.properties[prop] and \
-                                'Any' not in self.properties[prop]:
+                        if props[prop] not in [x.strip() for x in self.properties[prop].split(',')] and \
+                                'any' not in self.properties[prop].lower():
                             # Invalid property selected
                             raise IncompatibleDataPortConnectionPropsError
                     for d in dests:
                         if prop in d.properties:
-                            if props[prop] not in d.properties[prop] and \
-                                    'Any' not in d.properties[prop]:
+                            if props[prop] not in [x.strip() for x in d.properties[prop].split(',')] and \
+                                    'any' not in d.properties[prop].lower():
                                 # Invalid property selected
                                 raise IncompatibleDataPortConnectionPropsError
             if not name:


### PR DESCRIPTION
- RTC of OpenRTM.NET has multiple property value(subscription_type and
  dataflow_type), but rtctree treat as scalar value.
- 'Any' of OpenRTM.NET is lower case, but rtctree treat as upper case.
