### PR TITLE
omniORB.any is not attribute but package. Import first.

### DIFF
--- a/rtctree/utils.py
+++ b/rtctree/utils.py
@@ -21,6 +21,7 @@ of name servers, directories, managers and components.
 import sys
 
 import omniORB
+import omniORB.any
 
 from rtctree.rtc import SDOPackage
 


### PR DESCRIPTION
omniORB.any is not attribute but package. Import first.

Just added 
'import omniORB.any'
in utils.py